### PR TITLE
Use python official alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
-FROM alpine
+FROM python:3-alpine
 
-RUN apk add --no-cache py3-pip && \
-    pip install --break-system-packages --no-cache-dir --upgrade ansible ansible-lint yamllint
-
-CMD ["python3"]
+RUN pip install --no-cache-dir --upgrade ansible ansible-lint yamllint


### PR DESCRIPTION
These changes bring the following benefits:

1. Updated to the latest Python version (`3.12.5` in the official image vs. `3.12.3` in Alpine).
2. Faster builds by removing the need to manually install `py3-pip`.
3. Reduced image size by about 9MB.
4. Simpler Dockerfile by removing the redundant `CMD` stage.